### PR TITLE
Split the L0Smooth algorithm for Gray images and RGB images

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,12 @@ version = "0.1.0"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
 FFTW = "1"
 ImageBase = "0.1.2"
+OffsetArrays = "1.10.5"
 ImageFiltering = "0.6"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 [compat]
 FFTW = "1"
 ImageBase = "0.1.2"
-OffsetArrays = "1.10.5"
+OffsetArrays = "1"
 ImageFiltering = "0.6"
 julia = "1"
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -55,10 +55,9 @@ fₛ = L0Smooth()
 ```
 
 ```@repl smooth!
-input = reshape(channelview(img), 1, size(img)...);
-imgₛ = similar(float64.(input));
+imgₛ = similar(img);
 
-smooth!(imgₛ, input, fₛ);
+smooth!(imgₛ, img, fₛ);
 ```
 
 ## Demonstration
@@ -95,11 +94,10 @@ img = testimage("cameraman")
 
 fₛ = L0Smooth()
 
-input = reshape(channelview(img), 1, size(img)...)
-imgₛ = similar(float64.(input))
+imgₛ = similar(img)
 
-smooth!(imgₛ, input, fₛ)
+smooth!(imgₛ, img, fₛ)
 
 # View the original image and the smoothed image
-mosaicview(img, imgₛ[1, :, :]; nrow=1)
+mosaicview(img, imgₛ; nrow=1)
 ```

--- a/src/ImageSmooth.jl
+++ b/src/ImageSmooth.jl
@@ -3,6 +3,7 @@ module ImageSmooth
 using ImageFiltering, FFTW
 using ImageBase
 using ImageBase.ImageCore: GenericGrayImage, GenericImage
+using OffsetArrays
 
 #TODO: port SmoothAPI to ImagesAPI
 include("SmoothAPI/SmoothAPI.jl")

--- a/src/SmoothAPI/smooth.jl
+++ b/src/SmoothAPI/smooth.jl
@@ -19,16 +19,7 @@ fₛ = L0Smooth()
 imgₛ = smooth(img, fₛ)
 
 # Or use in-place version `smooth!`
-
-## Ror Gray images
-input = reshape(channelview(img), 1, size(img)...)
-imgₛ = similar(float64.(input))
-
-smooth!(imgₛ, input, fₛ)
-
-## For RGB images
-input = channelview(img)
-imgₛ = similar(float64.(input))
+imgₛ = similar(img)
 
 smooth!(imgₛ, img, fₛ)
 ```
@@ -49,8 +40,8 @@ algorithms.
 """
 abstract type AbstractImageSmoothAlgorithm <: AbstractImageFilter end
 
-smooth!(out::AbstractArray{<: Number},
-        img::AbstractArray{<: Number},
+smooth!(out::GenericImage,
+        img::GenericImage,
         f::AbstractImageSmoothAlgorithm,
         args...; kwargs...) =
     f(out, img, args...; kwargs...)
@@ -58,27 +49,25 @@ smooth!(out::AbstractArray{<: Number},
 function smooth(img::GenericGrayImage,
                 f::AbstractImageSmoothAlgorithm,
                 args...; kwargs...)
-    input = reshape(channelview(img), 1, size(img)...)
-    out = similar(input, Float64)
-    smooth!(out, input, f, args...; kwargs...)
-    return colorview(Gray, out[1, :, :])
+    out = similar(img)
+    smooth!(out, img, f, args...; kwargs...)
+    return out
 end
 
-function smooth(img::GenericImage{<:Color3},
+function smooth(img::GenericImage{<:AbstractRGB},
                 f::AbstractImageSmoothAlgorithm,
                 args...; kwargs...)
-    input = channelview(img)
-    out = similar(input, Float64)
-    smooth!(out, input, f, args...; kwargs...)
-    return colorview(RGB, out)
+    out = similar(img)
+    smooth!(out, img, f, args...; kwargs...)
+    return out
 end
 
 ### Docstrings
 
 """
-    smooth!(out::AbstractArray{<: Number}, img::AbstractArray{<: Number}, fₛ::AbstractImageSmoothAlgorithm, args...; kwargs...)
+    smooth!(out::GenericImage, img::GenericImage, fₛ::AbstractImageSmoothAlgorithm, args...; kwargs...)
 
-Smooth `img::AbstractArray{<: Number}` using algorithm `fₛ`
+Smooth `img::GenericImage` using algorithm `fₛ`
 
 # Output
 
@@ -92,15 +81,8 @@ Just simply pass an algorithm to `smooth!`:
 # First generate an algorithm instance
 fₛ = L0Smooth()
 
-## For Gray images
-input = reshape(channelview(img), 1, size(img)...)
-imgₛ = similar(float64.(input))
-
-smooth!(imgₛ, input, fₛ)
-
-## For RGB images
-input = channelview(img)
-imgₛ = similar(float64.(input))
+## For Gray or RGB images
+imgₛ = similar(img)
 
 smooth!(imgₛ, img, fₛ)
 ```
@@ -116,7 +98,7 @@ Smooth `img` using algorithm `fₛ`
 
 # Output
 
-The return image `imgₛ` is an `Array{Gray{Float64}} for `Gray` image, and `Array{RGB{Float64}}` for `RGB` image.
+The return image `imgₛ` is an `Array{Gray{N0f8}} for `Gray` image, and `Array{RGB{N0f8}}` for `RGB` image.
 
 # Examples
 

--- a/test/algorithms/l0_smooth.jl
+++ b/test/algorithms/l0_smooth.jl
@@ -26,8 +26,8 @@
         f = L0Smooth()
         smoothed_img_gray = smooth(img_gray, f)
         smoothed_img_rgb = smooth(img_rgb, f)
-        @test eltype(smoothed_img_gray) == Gray{Float64}
-        @test eltype(smoothed_img_rgb) == RGB{Float64}
+        @test eltype(smoothed_img_gray) == Gray{N0f8}
+        @test eltype(smoothed_img_rgb) == RGB{N0f8}
     end
 
     @testset "ReferenceTests" begin
@@ -49,5 +49,16 @@
         out = smooth(img_rgb, f)
         @test assess_psnr(out, eltype(out).(ref)) >= 27
         end
+    end
+
+    @testset "Offset Arrays" begin
+        # Verify that the algorithms give equivalent results on OffsetArrays
+        img = imresize(testimage("cameraman"), (64, 64))
+        offset_img = OffsetArray(img, OffsetArrays.Origin(0))
+        fₛ = L0Smooth()
+        imgₛ = smooth(img, fₛ)
+        offset_imgₛ = smooth(offset_img, fₛ)
+        @test axes(offset_imgₛ) == axes(offset_img)
+        @test imgₛ == OffsetArrays.no_offset_view(offset_imgₛ)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test, ReferenceTests, TestImages
 using FileIO
 using ImageTransformations, ImageQualityIndexes
 using ImageBase
+using OffsetArrays
 
 include("testutils.jl")
 


### PR DESCRIPTION
In this work, there are two main mission:
* First, split the L0Smooth algorithm for Gray images and RGB images. `smooth` API no longer do pre-process for the input image. The processing works should be done in the algorithm part.
* Second, `L0Smooth` now support the widely-used `OffsetArrays`.

It's glad to see that the performance for processing `Gray` input improved a lot.

The performance after using `ImageBase.fdiff`:
```julia
julia> img_gray = testimage("cameraman");

julia> f = L0Smooth()
L0Smooth(0.02, 2.0, 100000.0)

julia> @btime smooth(img_gray, f)
  393.819 ms (1449 allocations: 138.77 MiB)
```

Current performance after split the L0Smooth algorithm:
```julia
julia> img_gray = testimage("cameraman");

julia> f = L0Smooth()
L0Smooth(0.02, 2.0, 100000.0)

julia> @btime smooth(img_gray , f)
  229.504 ms (1434 allocations: 130.94 MiB)
```
